### PR TITLE
Fixes: compatibility, core, tpcc scenario

### DIFF
--- a/tpcc_common.lua
+++ b/tpcc_common.lua
@@ -22,6 +22,8 @@ ffi = require("ffi")
 
 ffi.cdef[[
 void sb_counter_inc(int, sb_counter_type);
+typedef uint32_t useconds_t;
+int usleep(useconds_t useconds);
 ]]
 
 
@@ -64,8 +66,11 @@ end
 function cmd_prepare()
    local drv = sysbench.sql.driver()
    local con = drv:connect()
+   local show_query="SHOW TABLES"
 
-   con:query("SET FOREIGN_KEY_CHECKS=0")
+   if drv:name() == "mysql" then 
+      con:query("SET FOREIGN_KEY_CHECKS=0")
+   end
    -- create tables in parallel table per thread
    for i = sysbench.tid % sysbench.opt.threads + 1, sysbench.opt.tables,
    sysbench.opt.threads do
@@ -74,8 +79,8 @@ function cmd_prepare()
 
    -- make sure all tables are created before we load data
    repeat
-       rs = con:query("SHOW TABLES")
-       sleep(1)
+      rs= con:query(show_query)
+      ffi.C.usleep(1000)
    until rs.nrows == sysbench.opt.tables * 9
 
    for i = sysbench.tid % sysbench.opt.threads + 1, sysbench.opt.scale,
@@ -110,17 +115,19 @@ function create_tables(drv, con, table_num)
    local engine_def = ""
    local extra_table_options = ""
    local query
-
+   local tinyint_type="smallint"
+   local datetime_type="timestamp"   
+   
    if drv:name() == "mysql" or drv:name() == "attachsql" or
       drv:name() == "drizzle"
    then
       engine_def = "/*! ENGINE = " .. sysbench.opt.mysql_storage_engine .. " */"
       extra_table_options = sysbench.opt.mysql_table_options or ""
+      tinyint_type="tinyint"
+      datetime_type="datetime"
    end
 
-
    print(string.format("Creating tables: %d\n", table_num))
-
 
    query = string.format([[
 	CREATE TABLE IF NOT EXISTS warehouse%d (
@@ -141,7 +148,7 @@ function create_tables(drv, con, table_num)
 
    query = string.format([[
 	create table IF NOT EXISTS district%d (
-	d_id tinyint not null, 
+	d_id ]] .. tinyint_type .. [[ not null, 
 	d_w_id smallint not null, 
 	d_name varchar(10), 
 	d_street_1 varchar(20), 
@@ -163,7 +170,7 @@ function create_tables(drv, con, table_num)
    query = string.format([[
 	create table IF NOT EXISTS customer%d (
 	c_id int not null, 
-	c_d_id tinyint not null,
+	c_d_id ]] .. tinyint_type .. [[ not null,
 	c_w_id smallint not null, 
 	c_first varchar(16), 
 	c_middle char(2), 
@@ -174,7 +181,7 @@ function create_tables(drv, con, table_num)
 	c_state char(2), 
 	c_zip char(9), 
 	c_phone char(16), 
-	c_since datetime, 
+	c_since ]] .. datetime_type .. [[, 
 	c_credit char(2), 
 	c_credit_lim bigint, 
 	c_discount decimal(4,2), 
@@ -194,11 +201,11 @@ function create_tables(drv, con, table_num)
    query = string.format([[
 	create table IF NOT EXISTS history%d (
 	h_c_id int, 
-	h_c_d_id tinyint, 
+	h_c_d_id ]] .. tinyint_type .. [[, 
 	h_c_w_id smallint,
-	h_d_id tinyint,
+	h_d_id ]] .. tinyint_type .. [[,
 	h_w_id smallint,
-	h_date datetime,
+	h_date ]] .. datetime_type .. [[,
 	h_amount decimal(6,2), 
 	h_data varchar(24)
 	) %s %s]],
@@ -209,13 +216,13 @@ function create_tables(drv, con, table_num)
    query = string.format([[
 	create table IF NOT EXISTS orders%d (
 	o_id int not null, 
-	o_d_id tinyint not null, 
+	o_d_id ]] .. tinyint_type .. [[ not null, 
 	o_w_id smallint not null,
 	o_c_id int,
-	o_entry_d datetime,
-	o_carrier_id tinyint,
-	o_ol_cnt tinyint, 
-	o_all_local tinyint,
+	o_entry_d ]] .. datetime_type .. [[,
+	o_carrier_id ]] .. tinyint_type .. [[,
+	o_ol_cnt ]] .. tinyint_type .. [[, 
+	o_all_local ]] .. tinyint_type .. [[,
 	PRIMARY KEY(o_w_id, o_d_id, o_id) 
 	) %s %s]],
       table_num, engine_def, extra_table_options)
@@ -227,7 +234,7 @@ function create_tables(drv, con, table_num)
    query = string.format([[
 	create table IF NOT EXISTS new_orders%d (
 	no_o_id int not null,
-	no_d_id tinyint not null,
+	no_d_id ]] .. tinyint_type .. [[ not null,
 	no_w_id smallint not null,
 	PRIMARY KEY(no_w_id, no_d_id, no_o_id)
 	) %s %s]],
@@ -238,13 +245,13 @@ function create_tables(drv, con, table_num)
    query = string.format([[
 	create table IF NOT EXISTS order_line%d ( 
 	ol_o_id int not null, 
-	ol_d_id tinyint not null,
+	ol_d_id ]] .. tinyint_type .. [[ not null,
 	ol_w_id smallint not null,
-	ol_number tinyint not null,
+	ol_number ]] .. tinyint_type .. [[ not null,
 	ol_i_id int, 
 	ol_supply_w_id smallint,
-	ol_delivery_d datetime, 
-	ol_quantity tinyint, 
+	ol_delivery_d ]] .. datetime_type .. [[, 
+	ol_quantity ]] .. tinyint_type .. [[, 
 	ol_amount decimal(6,2), 
 	ol_dist_info char(24),
 	PRIMARY KEY(ol_w_id, ol_d_id, ol_o_id, ol_number)
@@ -311,12 +318,12 @@ function create_tables(drv, con, table_num)
    con:bulk_insert_done()
 
     print(string.format("Adding indexes %d ... \n", i))
-    con:query("CREATE INDEX idx_customer ON customer"..i.." (c_w_id,c_d_id,c_last,c_first)")
-    con:query("CREATE INDEX idx_orders ON orders"..i.." (o_w_id,o_d_id,o_c_id,o_id)")
-    con:query("CREATE INDEX fkey_stock_2 ON stock"..i.." (s_i_id)")
-    con:query("CREATE INDEX fkey_order_line_2 ON order_line"..i.." (ol_supply_w_id,ol_i_id)")
-    con:query("CREATE INDEX fkey_history_1 ON history"..i.." (h_c_w_id,h_c_d_id,h_c_id)")
-    con:query("CREATE INDEX fkey_history_2 ON history"..i.." (h_w_id,h_d_id )")
+    con:query("CREATE INDEX idx_customer"..i.." ON customer"..i.." (c_w_id,c_d_id,c_last,c_first)")
+    con:query("CREATE INDEX idx_orders"..i.." ON orders"..i.." (o_w_id,o_d_id,o_c_id,o_id)")
+    con:query("CREATE INDEX fkey_stock_2"..i.." ON stock"..i.." (s_i_id)")
+    con:query("CREATE INDEX fkey_order_line_2"..i.." ON order_line"..i.." (ol_supply_w_id,ol_i_id)")
+    con:query("CREATE INDEX fkey_history_1"..i.." ON history"..i.." (h_c_w_id,h_c_d_id,h_c_id)")
+    con:query("CREATE INDEX fkey_history_2"..i.." ON history"..i.." (h_w_id,h_d_id )")
     if sysbench.opt.use_fk == 1 then
         print(string.format("Adding FK %d ... \n", i))
         con:query("ALTER TABLE new_orders"..i.." ADD CONSTRAINT fkey_new_orders_1_"..table_num.." FOREIGN KEY(no_w_id,no_d_id,no_o_id) REFERENCES orders"..i.."(o_w_id,o_d_id,o_id)")
@@ -330,7 +337,6 @@ function create_tables(drv, con, table_num)
         con:query("ALTER TABLE stock"..i.." ADD CONSTRAINT fkey_stock_1_"..table_num.." FOREIGN KEY(s_w_id) REFERENCES warehouse"..i.."(w_id)")
         con:query("ALTER TABLE stock"..i.." ADD CONSTRAINT fkey_stock_2_"..table_num.." FOREIGN KEY(s_i_id) REFERENCES item"..i.."(i_id)")
     end
-
 end
 
 
@@ -345,9 +351,7 @@ function set_isolation_level(drv,con)
             isolation_level="SERIALIZABLE"
         end
        
-        rs=con:query("SHOW VARIABLES LIKE 't%_isolation'")
-        row = rs:fetch_row()
-        isolation_variable = row[1]
+        isolation_variable=con:query_row("SHOW VARIABLES LIKE 't%_isolation'")
 
         con:query("SET SESSION " .. isolation_variable .. "='".. isolation_level .."'")
    end
@@ -465,7 +469,6 @@ function load_tables(drv, con, warehouse_num)
    con:bulk_insert_init("INSERT INTO orders" .. table_num .. [[
 	  (o_id, o_d_id, o_w_id, o_c_id, o_entry_d, o_carrier_id, o_ol_cnt, o_all_local) values]])
 
-
    a_counts[warehouse_num] = {}
 
    for d_id = 1 , DIST_PER_WARE do
@@ -485,32 +488,6 @@ function load_tables(drv, con, warehouse_num)
    end
 
    con:bulk_insert_done()
-
-   con:query(string.format("INSERT INTO new_orders%d (no_o_id, no_d_id, no_w_id) SELECT o_id, o_d_id, o_w_id FROM orders%d WHERE o_id>2100 and o_w_id=%d", table_num, table_num, warehouse_num))
-
-   con:bulk_insert_init("INSERT INTO order_line" .. table_num .. [[
-	  (ol_o_id, ol_d_id, ol_w_id, ol_number, ol_i_id, ol_supply_w_id, ol_delivery_d, 
-           ol_quantity, ol_amount, ol_dist_info ) values]])
-
-
-   for d_id = 1 , DIST_PER_WARE do
-   for o_id = 1 , 3000 do
-   for ol_id = 1, a_counts[warehouse_num][d_id][o_id] do 
- 
-      query = string.format([[(%d, %d, %d, %d, %d, %d, %s, 5, %f, '%s' )]],
-	    o_id, d_id, warehouse_num, ol_id, sysbench.rand.uniform(1, MAXITEMS), warehouse_num,
-        o_id < 2101 and "NOW()" or "NULL", 
-        o_id < 2101 and 0 or sysbench.rand.uniform_double()*9999.99,
-	string.rep(sysbench.rand.string("@"),24)
-        )
-      con:bulk_insert_next(query)
-
-   end
-   end 
-   end
-
-   con:bulk_insert_done()
-
 
 -- STOCK table
 
@@ -536,8 +513,33 @@ function load_tables(drv, con, warehouse_num)
       con:bulk_insert_next(query)
 
    end 
- con:bulk_insert_done()
- end
+   con:bulk_insert_done()
+
+   con:query(string.format("INSERT INTO new_orders%d (no_o_id, no_d_id, no_w_id) SELECT o_id, o_d_id, o_w_id FROM orders%d WHERE o_id>2100 and o_w_id=%d", table_num, table_num, warehouse_num))
+
+   con:bulk_insert_init("INSERT INTO order_line" .. table_num .. [[
+	  (ol_o_id, ol_d_id, ol_w_id, ol_number, ol_i_id, ol_supply_w_id, ol_delivery_d, 
+           ol_quantity, ol_amount, ol_dist_info ) values]])
+
+   for d_id = 1 , DIST_PER_WARE do
+   for o_id = 1 , 3000 do
+   for ol_id = 1, a_counts[warehouse_num][d_id][o_id] do 
+ 
+      query = string.format([[(%d, %d, %d, %d, %d, %d, %s, 5, %f, '%s' )]],
+	    o_id, d_id, warehouse_num, ol_id, sysbench.rand.uniform(1, MAXITEMS), warehouse_num,
+        o_id < 2101 and "NOW()" or "NULL", 
+        o_id < 2101 and 0 or sysbench.rand.uniform_double()*9999.99,
+	string.rep(sysbench.rand.string("@"),24)
+        )
+      res=con:bulk_insert_next(query)
+      
+   end
+   end 
+   end
+
+   con:bulk_insert_done()
+
+  end
 
 end
 
@@ -556,7 +558,9 @@ function cleanup()
    local drv = sysbench.sql.driver()
    local con = drv:connect()
 
-   con:query("SET FOREIGN_KEY_CHECKS=0")
+   if drv:name() == "mysql" then 
+      con:query("SET FOREIGN_KEY_CHECKS=0")
+   end
 
    for i = 1, sysbench.opt.tables do
       print(string.format("Dropping tables '%d'...", i))

--- a/tpcc_run.lua
+++ b/tpcc_run.lua
@@ -78,50 +78,41 @@ function new_order()
 --  AND c_id = :c_id;
 
   con:query("BEGIN")
-  rs = con:query(([[SELECT c_discount, c_last, c_credit, w_tax 
-                   FROM customer%d, warehouse%d
-                   WHERE w_id = %d AND c_w_id = w_id AND c_d_id = %d AND c_id = %d]]):
-		  format(table_num, table_num, w_id, d_id, c_id))
 
   local c_discount
   local c_last
   local c_credit
   local w_tax
-  for i = 1, rs.nrows do
-    row = rs:fetch_row()
-    c_discount = row[1]
-    c_last = row[2]
-    c_credit = row[3]
-    w_tax = row[4]
-    -- print(row[1], row[2], row[3], row[4])
-  end
-  --rs.free()
+
+  c_discount, c_last, c_credit, w_tax = con:query_row(([[SELECT c_discount, c_last, c_credit, w_tax 
+                                                           FROM customer%d, warehouse%d
+                                                          WHERE w_id = %d 
+                                                            AND c_w_id = w_id 
+                                                            AND c_d_id = %d 
+                                                            AND c_id = %d]]):
+                                                         format(table_num, table_num, w_id, d_id, c_id))
 
 --        SELECT d_next_o_id, d_tax INTO :d_next_o_id, :d_tax
 --                FROM district
 --                WHERE d_id = :d_id
 --                AND d_w_id = :w_id
 --                FOR UPDATE
-  rs = con:query(("SELECT d_next_o_id, d_tax FROM district%d".. 
-                 " WHERE d_w_id = %d AND d_id = %d FOR UPDATE"):format(table_num, w_id, d_id))
-
   local d_next_o_id
   local d_tax
-  for i = 1, rs.nrows do
-    row = rs:fetch_row()
-    d_next_o_id = row[1]
-    d_tax = row[2]
-    -- print(row[1], row[2])
-  end
-  --rs.free()
- 
+
+  d_next_o_id, d_tax = con:query_row(([[SELECT d_next_o_id, d_tax 
+                                          FROM district%d 
+                                         WHERE d_w_id = %d 
+                                           AND d_id = %d FOR UPDATE]]):
+                                        format(table_num, w_id, d_id))
+
 -- UPDATE district SET d_next_o_id = :d_next_o_id + 1
 --                WHERE d_id = :d_id 
 --                AND d_w_id = :w_id;
 
-  con:query(("UPDATE district%d"..
-            " SET d_next_o_id = %d".. 
-            " WHERE d_id = %d AND d_w_id= %d"):format(table_num, d_next_o_id + 1, d_id, w_id))
+  con:query(([[UPDATE district%d
+                  SET d_next_o_id = %d
+                WHERE d_id = %d AND d_w_id= %d]]):format(table_num, d_next_o_id + 1, d_id, w_id))
 
 --INSERT INTO orders (o_id, o_d_id, o_w_id, o_c_id,
 --                                    o_entry_d, o_ol_cnt, o_all_local)
@@ -129,17 +120,17 @@ function new_order()
 --                       :datetime,
 --                       :o_ol_cnt, :o_all_local);
 
-  con:query(("INSERT INTO orders%d".. 
-            "(o_id, o_d_id, o_w_id, o_c_id,  o_entry_d, o_ol_cnt, o_all_local)"..
-            " VALUES (%d,%d,%d,%d,NOW(),%d,%d)"):format(
-            table_num, d_next_o_id, d_id, w_id, c_id, ol_cnt, all_local))
+  con:query(([[INSERT INTO orders%d
+                           (o_id, o_d_id, o_w_id, o_c_id,  o_entry_d, o_ol_cnt, o_all_local)
+                    VALUES (%d,%d,%d,%d,NOW(),%d,%d)]]):
+                    format(table_num, d_next_o_id, d_id, w_id, c_id, ol_cnt, all_local))
 
 -- INSERT INTO new_orders (no_o_id, no_d_id, no_w_id)
 --    VALUES (:o_id,:d_id,:w_id); */
 
-  con:query(("INSERT INTO new_orders%d (no_o_id, no_d_id, no_w_id)"..
-            " VALUES (%d,%d,%d)"):format(
-            table_num, d_next_o_id, d_id, w_id))
+  con:query(([[INSERT INTO new_orders%d (no_o_id, no_d_id, no_w_id)
+                    VALUES (%d,%d,%d)]]):
+                   format(table_num, d_next_o_id, d_id, w_id))
 
   for ol_number=1, ol_cnt do
 	local ol_supply_w_id = supware[ol_number]
@@ -151,28 +142,23 @@ function new_order()
 --	FROM item
 --	WHERE i_id = :ol_i_id;*/
 
-	  rs = con:query(("SELECT i_price, i_name, i_data FROM item%d"..
-			 " WHERE i_id = %d"):format(
-			 table_num, ol_i_id))
+	rs = con:query(([[SELECT i_price, i_name, i_data 
+	                    FROM item%d
+	                   WHERE i_id = %d]]):
+	                  format(table_num, ol_i_id))
 
-	  local i_price
-	  local i_name
-	  local i_data
+	local i_price
+	local i_name
+	local i_data
 
-	  if rs.nrows == 0 then
-            --print("ROLLBACK")
-            ffi.C.sb_counter_inc(sysbench.tid, ffi.C.SB_CNT_ERROR)
-            con:query("ROLLBACK")
-	    return	
-          end
-
-	  for i = 1, rs.nrows do
-	    row = rs:fetch_row()
-	    i_price = row[1]
-	    i_name = row[2]
-	    i_data = row[3]
-	    -- print(row[1], row[2], row[3])
-	  end
+	if rs.nrows == 0 then
+--          print("ROLLBACK")
+          ffi.C.sb_counter_inc(sysbench.tid, ffi.C.SB_CNT_ERROR)
+          con:query("ROLLBACK")
+	  return	
+        end
+        
+        i_price, i_name, i_data = unpack(rs:fetch_row(), 1, rs.nfields)
         
 -- SELECT s_quantity, s_data, s_dist_01, s_dist_02,
 --		s_dist_03, s_dist_04, s_dist_05, s_dist_06,
@@ -185,23 +171,18 @@ function new_order()
 --	AND s_w_id = :ol_supply_w_id
 --	FOR UPDATE;*/
 
-	  rs = con:query(("SELECT s_quantity, s_data, s_dist_%s" ..
-                         " s_dist FROM stock%d"..
-			 " WHERE s_i_id = %d AND s_w_id= %d".. 
-                         " FOR UPDATE"):format(string.format("%02d",d_id),table_num,ol_i_id,ol_supply_w_id ))
-          local s_quantity 
-          local s_data 
-          local ol_dist_info
-	  for i = 1, rs.nrows do
-	    row = rs:fetch_row()
-	    s_quantity = tonumber(row[1])
-	    s_data = row[2]
-	    ol_dist_info = row[3]
-	    -- print(row[1], row[2], row[3])
-	  end
+        local s_quantity 
+        local s_data 
+        local ol_dist_info
 
-	if s_quantity > ol_quantity then
-		s_quantity = s_quantity - ol_quantity
+	s_quantity, s_data, ol_dist_info = con:query_row(([[SELECT s_quantity, s_data, s_dist_%s s_dist 
+	                                                      FROM stock%d  
+	                                                     WHERE s_i_id = %d AND s_w_id= %d FOR UPDATE]]):
+	                                                     format(string.format("%02d",d_id),table_num,ol_i_id,ol_supply_w_id ))
+     
+        s_quantity=tonumber(s_quantity)
+  	if (s_quantity > ol_quantity) then
+	        s_quantity = s_quantity - ol_quantity
 	else
 		s_quantity = s_quantity - ol_quantity + 91
 	end
@@ -210,12 +191,18 @@ function new_order()
 --	WHERE s_i_id = :ol_i_id 
 --	AND s_w_id = :ol_supply_w_id;*/
 
-	  con:query(("UPDATE stock%d"..
-		    " SET s_quantity = %d"..
-		    " WHERE s_i_id = %d AND s_w_id= %d"):format(
-		    table_num, s_quantity, ol_i_id, ol_supply_w_id))
+	con:query(([[UPDATE stock%d
+	                SET s_quantity = %d
+	              WHERE s_i_id = %d 
+		        AND s_w_id= %d]]):
+		    format(table_num, s_quantity, ol_i_id, ol_supply_w_id))
    
-	  ol_amount = ol_quantity * i_price * (1 + w_tax + d_tax) * (1 - c_discount);
+        i_price=tonumber(i_price)
+        w_tax=tonumber(w_tax)
+        d_tax=tonumber(d_tax)        
+        c_discount=tonumber(c_discount)
+        
+	ol_amount = ol_quantity * i_price * (1 + w_tax + d_tax) * (1 - c_discount);
 
 -- INSERT INTO order_line (ol_o_id, ol_d_id, ol_w_id, 
 --				 ol_number, ol_i_id, 
@@ -225,13 +212,13 @@ function new_order()
 --		:ol_supply_w_id, :ol_quantity, :ol_amount,
 --		:ol_dist_info);
 
-	  con:query(("INSERT INTO order_line%d" ..
-	            " (ol_o_id, ol_d_id, ol_w_id, ol_number, ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_dist_info)"..
-		    " VALUES (%d,%d,%d,%d,%d,%d,%d,%d,'%s')"):format(
-                    table_num, d_next_o_id, d_id, w_id, ol_number, ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_dist_info)
-                   )
+	con:query(([[INSERT INTO order_line%d
+                                 (ol_o_id, ol_d_id, ol_w_id, ol_number, ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_dist_info)
+	                  VALUES (%d,%d,%d,%d,%d,%d,%d,%d,'%s')]]):
+	                  format(table_num, d_next_o_id, d_id, w_id, ol_number, ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_dist_info))
 
   end
+
   con:query("COMMIT")
 
 end
@@ -268,9 +255,9 @@ function payment()
 
   con:query("BEGIN")
 
-  con:query(("UPDATE warehouse%d"..
-	    " SET w_ytd = w_ytd + %d "..
-	    " WHERE w_id = %d"):format(table_num, h_amount, w_id ))
+  con:query(([[UPDATE warehouse%d
+	          SET w_ytd = w_ytd + %d 
+	        WHERE w_id = %d]]):format(table_num, h_amount, w_id ))
 
 -- SELECT w_street_1, w_street_2, w_city, w_state, w_zip,
 --		w_name
@@ -278,54 +265,30 @@ function payment()
 --			:w_zip, :w_name
 --		FROM warehouse
 --		WHERE w_id = :w_id;*/
+  local w_street_1, w_street_2, w_city, w_state, w_zip, w_name
 
-  rs = con:query(("SELECT w_street_1, w_street_2, w_city, w_state, w_zip, w_name "..
-                  " FROM warehouse%d  WHERE w_id = %d"):format(table_num, w_id))
-
-  local w_street_1
-  local w_street_2
-  local w_city
-  local w_state
-  local w_zip
-  local w_name
-  for i = 1, rs.nrows do
-    row = rs:fetch_row()
-    w_street_1 = row[1]
-    w_street_2 = row[2]
-    w_city = row[3]
-    w_state = row[4]
-    w_zip = row[5]
-    w_name = row[6]
-    -- print(row[1], row[2], row[3], row[4])
-  end
+  w_street_1, w_street_2, w_city, w_state, w_zip, w_name =
+                          con:query_row(([[SELECT w_street_1, w_street_2, w_city, w_state, w_zip, w_name 
+                                             FROM warehouse%d  
+                                            WHERE w_id = %d]]):format(table_num, w_id))
 
 -- UPDATE district SET d_ytd = d_ytd + :h_amount
 --		WHERE d_w_id = :w_id 
 --		AND d_id = :d_id;*/
 
-  con:query(("UPDATE district%d SET d_ytd = d_ytd + %d WHERE d_w_id = %d AND d_id= %d"):format(
-	    table_num, h_amount, w_id, d_id))
+  con:query(([[UPDATE district%d 
+                 SET d_ytd = d_ytd + %d 
+               WHERE d_w_id = %d 
+                 AND d_id= %d]]):format(table_num, h_amount, w_id, d_id))
 
-  rs = con:query(("SELECT d_street_1, d_street_2, d_city, d_state, d_zip, d_name FROM district%d"..
-                 " WHERE d_w_id = %d AND d_id= %d"):format(table_num, w_id, d_id ))
 
-  local d_street_1
-  local d_street_2
-  local d_city
-  local d_state
-  local d_zip
-  local d_name
-  for i = 1, rs.nrows do
-    row = rs:fetch_row()
-    d_street_1 = row[1]
-    d_street_2 = row[2]
-    d_city = row[3]
-    d_state = row[4]
-    d_zip = row[5]
-    d_name = row[6]
-    -- print(row[1], row[2], row[3], row[4])
-  end
+  local d_street_1,d_street_2, d_city, d_state, d_zip, d_name
 
+  d_street_1,d_street_2, d_city, d_state, d_zip, d_name = 
+                          con:query_row(([[SELECT d_street_1, d_street_2, d_city, d_state, d_zip, d_name 
+                                             FROM district%d
+                                            WHERE d_w_id = %d 
+                                              AND d_id = %d]]):format(table_num, w_id, d_id ))
 
   if byname == 1 then
 
@@ -334,16 +297,12 @@ function payment()
 --	WHERE c_w_id = :c_w_id
 --	AND c_d_id = :c_d_id
 --	AND c_last = :c_last;*/
-	rs = con:query(([[SELECT count(c_id) namecnt
-			   FROM customer%d
-			   WHERE c_w_id = %d AND c_d_id= %d
-                           AND c_last='%s']]):format(table_num, w_id, c_d_id, c_last ))
-	local namecnt
-	for i = 1, rs.nrows do
-		row = rs:fetch_row()
-		namecnt = row[1]
-	end
   
+	local namecnt = con:query_row(([[SELECT count(c_id) namecnt
+			                   FROM customer%d
+			                  WHERE c_w_id = %d 
+			                    AND c_d_id= %d
+                                            AND c_last='%s']]):format(table_num, w_id, c_d_id, c_last ))
 --		SELECT c_id
 --		FROM customer
 --		WHERE c_w_id = :c_w_id 
@@ -351,16 +310,17 @@ function payment()
 --		AND c_last = :c_last
 --		ORDER BY c_first;
 
-	rs = con:query(([[SELECT c_id
-			   FROM customer%d
-			   WHERE c_w_id = %d AND c_d_id= %d
-                           AND c_last='%s' ORDER BY c_first]]
-			):format(table_num, w_id, c_d_id, c_last ))
-
 	if namecnt % 2 == 0 then
 		namecnt = namecnt + 1
 	end
-	for i = 1,  (namecnt % 2 ) + 1 do
+
+	rs = con:query(([[SELECT c_id
+		 	    FROM customer%d
+			   WHERE c_w_id = %d AND c_d_id= %d
+                             AND c_last='%s' ORDER BY c_first]]
+			):format(table_num, w_id, c_d_id, c_last ))
+
+	for i = 1,  (namecnt / 2 ) + 1 do
 		row = rs:fetch_row()
 		c_id = row[1]
 	end
@@ -376,69 +336,38 @@ function payment()
 --	AND c_id = :c_id
 --	FOR UPDATE;
 
-	rs = con:query(([[SELECT c_first, c_middle, c_last, c_street_1,
-                         c_street_2, c_city, c_state, c_zip, c_phone,
-                         c_credit, c_credit_lim, c_discount, c_balance, c_ytd_payment, c_since
-			   FROM customer%d
-			   WHERE c_w_id = %d AND c_d_id= %d
-			   AND c_id=%d FOR UPDATE]])
+  local c_first, c_middle, c_last, c_street_1, c_street_2, c_city, c_state, c_zip,
+        c_phone, c_credit, c_credit_lim, c_discount, c_balance, c_ytd_payment, c_since
+
+  c_first, c_middle, c_last, c_street_1, c_street_2, c_city, c_state, c_zip,
+  c_phone, c_credit, c_credit_lim, c_discount, c_balance, c_ytd_payment, c_since =
+	 con:query_row(([[SELECT c_first, c_middle, c_last, c_street_1,
+                                 c_street_2, c_city, c_state, c_zip, c_phone,
+                                 c_credit, c_credit_lim, c_discount, c_balance, c_ytd_payment, c_since
+			    FROM customer%d
+			   WHERE c_w_id = %d 
+			     AND c_d_id= %d
+			     AND c_id=%d FOR UPDATE]])
 			 :format(table_num, w_id, c_d_id, c_id ))
-  local c_first
-  local c_middle
-  local c_last
-  local c_street_1
-  local c_street_2
-  local c_city
-  local c_state
-  local c_zip
-  local c_phone
-  local c_credit
-  local c_credit_lim
-  local c_discount
-  local c_balance
-  local c_ytd_payment
-  local c_since
-  for i = 1, rs.nrows do
-	row = rs:fetch_row()
-	c_first = row[1]
-	c_middle = row[2]
-	c_last = row[3]
-	c_street_1 = row[4]
-	c_street_2 = row[5]
-	c_city = row[6]
-	c_state = row[7]
-	c_zip = row[8]
-	c_phone = row[9]
-	c_credit = row[10]
-	c_credit_lim = row[11]
-	c_discount = row[12]
-	c_balance = row[13]
-	c_ytd_payment = row[14]
-	c_since = row[15]
-    -- print(row[1], row[2], row[3], row[4])
-  end
 
   c_balance = tonumber(c_balance) - h_amount
   c_ytd_payment = tonumber(c_ytd_payment) + h_amount
 
-    if c_credit == "BC" then
+  if c_credit == "BC" then
 -- SELECT c_data 
 --	INTO :c_data
 --	FROM customer
 --	WHERE c_w_id = :c_w_id 
 --	AND c_d_id = :c_d_id 
 -- 	AND c_id = :c_id; */
-
-        rs = con:query(([[SELECT c_data
-                         FROM customer%d
-                         WHERE c_w_id = %d AND c_d_id=%d
-                          AND c_id= %d]])
-			:format(table_num, w_id, c_d_id, c_id ))
+    
         local c_data
-        for i = 1, rs.nrows do
-            row = rs:fetch_row()
-            c_data = row[1]
-        end
+        c_data = con:query_row(([[SELECT c_data
+                                    FROM customer%d
+                                   WHERE c_w_id = %d 
+                                     AND c_d_id=%d
+                                     AND c_id= %d]]):
+                                  format(table_num, w_id, c_d_id, c_id ))
 
         local c_new_data=string.sub(string.format("| %4d %2d %4d %2d %4d $%7.2f %12s %24s",
                 c_id, c_d_id, c_w_id, d_id, w_id, h_amount, os.time(), c_data), 1, 500);
@@ -449,18 +378,20 @@ function payment()
     --			AND c_d_id = :c_d_id 
     --			AND c_id = :c_id
         con:query(([[UPDATE customer%d
-                   SET c_balance=%f, c_ytd_payment=%f, c_data='%s'
-                   WHERE c_w_id = %d AND c_d_id=%d
-                       AND c_id=%d]])
+                        SET c_balance=%f, c_ytd_payment=%f, c_data='%s'
+                      WHERE c_w_id = %d 
+                        AND c_d_id=%d
+                        AND c_id=%d]])
 		  :format(table_num, c_balance, c_ytd_payment, c_new_data, w_id, c_d_id, c_id  ))
-    else
+  else
         con:query(([[UPDATE customer%d
-                    SET c_balance=%f, c_ytd_payment=%f
-                    WHERE c_w_id = %d AND c_d_id=%d
-                          AND c_id=%d]])
+                        SET c_balance=%f, c_ytd_payment=%f
+                      WHERE c_w_id = %d 
+                        AND c_d_id=%d
+                        AND c_id=%d]])
 		  :format(table_num, c_balance, c_ytd_payment, w_id, c_d_id, c_id  ))
 
-    end
+  end
 
 --	INSERT INTO history(h_c_d_id, h_c_w_id, h_c_id, h_d_id,
 --			                   h_w_id, h_date, h_amount, h_data)
@@ -470,10 +401,12 @@ function payment()
 --			       :h_amount, :h_data);*/
 			       
   con:query(([[INSERT INTO history%d
-              (h_c_d_id, h_c_w_id, h_c_id, h_d_id,  h_w_id, h_date, h_amount, h_data)
-             VALUES (%d,%d,%d,%d,%d,NOW(),%d,'%s')]])
+                           (h_c_d_id, h_c_w_id, h_c_id, h_d_id,  h_w_id, h_date, h_amount, h_data)
+                    VALUES (%d,%d,%d,%d,%d,NOW(),%d,'%s')]])
             :format(table_num, c_d_id, c_w_id, c_id, d_id,  w_id, h_amount, string.format("%10s %10s    ",w_name,d_name)))
-con:query("COMMIT")
+
+  con:query("COMMIT")
+
 end
 
 function orderstatus()
@@ -503,39 +436,37 @@ function orderstatus()
 --        AND c_d_id = :c_d_id
 --            AND c_last = :c_last;*/
 
-        rs = con:query(([[SELECT count(c_id) namecnt
-                   FROM customer%d
-                   WHERE c_w_id = %d AND c_d_id= %d
-                    AND c_last='%s']])
-		:format(table_num, w_id, d_id, c_last ))
         local namecnt
-        for i = 1, rs.nrows do
-            row = rs:fetch_row()
-            namecnt = row[1]
-        end
+        namecnt = con:query_row(([[SELECT count(c_id) namecnt
+                                     FROM customer%d
+                                    WHERE c_w_id = %d 
+                                      AND c_d_id= %d
+                                      AND c_last='%s']]):
+                                  format(table_num, w_id, d_id, c_last ))
 
---            SELECT c_balance, c_first, c_middle, c_last
+--            SELECT c_balance, c_first, c_middle, c_id
 --            FROM customer
 --            WHERE c_w_id = :c_w_id
 --        AND c_d_id = :c_d_id
 --        AND c_last = :c_last
 --        ORDER BY c_first;
 
-        rs = con:query(([[SELECT c_balance, c_first, c_middle, c_last
-                   	FROM customer%d
-                  	WHERE c_w_id = %d AND c_d_id= %d
-                              AND c_last='%s' ORDER BY c_first]])
+        rs = con:query(([[SELECT c_balance, c_first, c_middle, c_id
+                            FROM customer%d
+                	   WHERE c_w_id = %d 
+                  	     AND c_d_id= %d
+                             AND c_last='%s' ORDER BY c_first]])
 		:format(table_num, w_id, d_id, c_last ))
 
         if namecnt % 2 == 0 then
             namecnt = namecnt + 1
         end
-        for i = 1,  (namecnt % 2 ) + 1 do
+        for i = 1,  (namecnt / 2 ) + 1 do
             row = rs:fetch_row()
             c_balance = row[1]
             c_first = row[2]
             c_middle = row[3]
-            c_last = row[4]
+            c_id = row[4]
         end
     else
 --		SELECT c_balance, c_first, c_middle, c_last
@@ -543,32 +474,40 @@ function orderstatus()
 --		        WHERE c_w_id = :c_w_id
 --			AND c_d_id = :c_d_id
 --			AND c_id = :c_id;*/
-        rs = con:query(([[SELECT c_balance, c_first, c_middle, c_last
-                   	FROM customer%d
-                   	WHERE c_w_id = %d AND c_d_id=%d
-                              AND c_id=%d]])
-		:format(table_num, w_id, d_id, c_id ))
-        for i = 1, rs.nrows do
-            row = rs:fetch_row()
-            c_balance = row[1]
-            c_first = row[2]
-            c_middle = row[3]
-            c_last = row[4]
-        end
-    
+        c_balance, c_first, c_middle, c_last = 
+                   con:query_row(([[SELECT c_balance, c_first, c_middle, c_last
+                                      FROM customer%d
+                   	             WHERE c_w_id = %d 
+                   	               AND c_d_id=%d
+                                       AND c_id=%d]])
+                                  :format(table_num, w_id, d_id, c_id ))
     end
--- SELECT o_id, o_entry_d, COALESCE(o_carrier_id,0) FROM orders WHERE o_w_id = ? AND o_d_id = ? AND o_c_id = ? AND o_id = (SELECT MAX(o_id) FROM orders WHERE o_w_id = ? AND o_d_id = ? AND o_c_id = ?)
+--[=[ Initial query
+        SELECT o_id, o_entry_d, COALESCE(o_carrier_id,0) FROM orders 
+        WHERE o_w_id = ? AND o_d_id = ? AND o_c_id = ? AND o_id = 
+        (SELECT MAX(o_id) FROM orders WHERE o_w_id = ? AND o_d_id = ? AND o_c_id = ?)
 
-    rs = con:query(([[SELECT o_id, o_entry_d, COALESCE(o_carrier_id,0) 
+        rs = con:query(([[SELECT o_id, o_entry_d, COALESCE(o_carrier_id,0) 
                   FROM orders%d WHERE o_w_id = %d AND o_d_id = %d AND o_c_id = %d AND o_id = 
                   (SELECT MAX(o_id) FROM orders%d WHERE o_w_id = %d AND o_d_id = %d AND o_c_id = %d)]])
-                  :format(table_num, w_id, d_id, c_id, table_num, w_id, d_id, c_id))
-    local o_id
- 
-    for i = 1, rs.nrows do
-        row = rs:fetch_row()
-        o_id = row[1]
-    end
+                  :format(table_num, w_id, d_id, c_id, table_num, w_id, d_id, c_id)) 
+--]=]
+                  
+--[[ Query from tpcc standard
+
+  EXEC SQL SELECT o_id, o_carrier_id, o_entry_d
+  INTO :o_id, :o_carrier_id, :entdate
+  FROM orders
+  ORDER BY o_id DESC;
+-]]
+      local o_id
+      o_id = con:query_row(([[SELECT o_id, o_carrier_id, o_entry_d
+                                FROM orders%d 
+                               WHERE o_w_id = %d 
+                                 AND o_d_id = %d 
+                                 AND o_c_id = %d 
+                                  ORDER BY o_id DESC]]):
+                             format(table_num, w_id, d_id, c_id))
 
 --		SELECT ol_i_id, ol_supply_w_id, ol_quantity, ol_amount,
 --                       ol_delivery_d
@@ -576,6 +515,7 @@ function orderstatus()
 --	        WHERE ol_w_id = :c_w_id
 --		AND ol_d_id = :c_d_id
 --		AND ol_o_id = :o_id;*/
+
     rs = con:query(([[SELECT ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_delivery_d
             FROM order_line%d WHERE ol_w_id = %d AND ol_d_id = %d  AND ol_o_id = %d]])
                   :format(table_num, w_id, d_id, d_id, o_id))
@@ -597,59 +537,72 @@ function delivery()
     local o_carrier_id = sysbench.rand.uniform(1, 10)
 
     con:query("BEGIN")
-	for d_id = 1, DIST_PER_WARE do
+    for  d_id = 1, DIST_PER_WARE do
 
 --	SELECT COALESCE(MIN(no_o_id),0) INTO :no_o_id
 --		                FROM new_orders
 --		                WHERE no_d_id = :d_id AND no_w_id = :w_id;*/
 		                
-        rs = con:query(([[SELECT COALESCE(MIN(no_o_id),0) no_o_id
-                 FROM new_orders%d WHERE no_d_id = %d AND no_w_id = %d FOR UPDATE]])
-                      :format(table_num, d_id, w_id))
-                 -- FROM new_orders%d WHERE no_d_id = %d AND no_w_id = %d]],
+--        rs = con:query(([[SELECT COALESCE(MIN(no_o_id),0) no_o_id
+--                 FROM new_orders%d WHERE no_d_id = %d AND no_w_id = %d FOR UPDATE]])
+--                      :format(table_num, d_id, w_id))
+
         local no_o_id
-        for i = 1,  rs.nrows do
-            row = rs:fetch_row()
-            no_o_id = row[1]
+        
+        rs = con:query(([[SELECT no_o_id
+                                     FROM new_orders%d 
+                                    WHERE no_d_id = %d 
+                                      AND no_w_id = %d 
+                                      ORDER BY no_o_id ASC LIMIT 1 FOR UPDATE]])
+                                   :format(table_num, d_id, w_id))
+
+        if (rs.nrows > 0) then
+          no_o_id=unpack(rs:fetch_row(), 1, rs.nfields)
         end
 
-		if tonumber(no_o_id) == 0 then goto continue end
-
+        if (no_o_id ~= nil ) then 
+        
 --		DELETE FROM new_orders WHERE no_o_id = :no_o_id AND no_d_id = :d_id
 --		  AND no_w_id = :w_id;*/
 
         con:query(([[DELETE FROM new_orders%d
-                WHERE no_o_id = %d AND no_d_id = %d  AND no_w_id = %d]])
-                      :format(table_num, no_o_id, d_id, w_id))
+                           WHERE no_o_id = %d 
+                             AND no_d_id = %d  
+                             AND no_w_id = %d]])
+                            :format(table_num, no_o_id, d_id, w_id))
 
 --  SELECT o_c_id INTO :c_id FROM orders
 --		                WHERE o_id = :no_o_id AND o_d_id = :d_id
 --				AND o_w_id = :w_id;*/
 
-        rs = con:query(([[SELECT o_c_id
-                FROM orders%d WHERE o_id = %d AND o_d_id = %d AND o_w_id = %d]])
-                      :format(table_num, no_o_id, d_id, w_id))
-
         local o_c_id
-        for i = 1,  rs.nrows do
-            row = rs:fetch_row()
-            o_c_id = row[1]
-        end
+        o_c_id = con:query_row(([[SELECT o_c_id
+                                    FROM orders%d 
+                                   WHERE o_id = %d 
+                                     AND o_d_id = %d 
+                                     AND o_w_id = %d]])
+                                  :format(table_num, no_o_id, d_id, w_id))
 
 --	 UPDATE orders SET o_carrier_id = :o_carrier_id
 --		                WHERE o_id = :no_o_id AND o_d_id = :d_id AND
 --				o_w_id = :w_id;*/
 
-        con:query(([[UPDATE orders%d SET o_carrier_id = %d
-                WHERE o_id = %d AND o_d_id = %d AND o_w_id = %d]])
+        con:query(([[UPDATE orders%d 
+                        SET o_carrier_id = %d
+                      WHERE o_id = %d 
+                        AND o_d_id = %d 
+                        AND o_w_id = %d]])
                       :format(table_num, o_carrier_id, no_o_id, d_id, w_id))
 
 --   UPDATE order_line
 --		                SET ol_delivery_d = :datetime
 --		                WHERE ol_o_id = :no_o_id AND ol_d_id = :d_id AND
 --				ol_w_id = :w_id;*/
-        con:query(([[UPDATE order_line%d SET ol_delivery_d = NOW()
-                WHERE ol_o_id = %d AND ol_d_id = %d AND ol_w_id = %d]])
+        con:query(([[UPDATE order_line%d 
+                        SET ol_delivery_d = NOW()
+                      WHERE ol_o_id = %d 
+                        AND ol_d_id = %d 
+                        AND ol_w_id = %d]])
                       :format(table_num, no_o_id, d_id, w_id))
 
 --	 SELECT SUM(ol_amount) INTO :ol_total
@@ -657,27 +610,28 @@ function delivery()
 --		                WHERE ol_o_id = :no_o_id AND ol_d_id = :d_id
 --				AND ol_w_id = :w_id;*/
 
-        rs = con:query(([[SELECT SUM(ol_amount) sm
-                FROM order_line%d WHERE ol_o_id = %d AND ol_d_id = %d AND ol_w_id = %d]])
-                      :format(table_num, no_o_id, d_id, w_id))
-
         local sm_ol_amount
-        for i = 1,  rs.nrows do
-            row = rs:fetch_row()
-            sm_ol_amount = row[1]
-        end
+        sm_ol_amount = con:query_row(([[SELECT SUM(ol_amount) sm
+                                          FROM order_line%d 
+                                         WHERE ol_o_id = %d 
+                                           AND ol_d_id = %d 
+                                           AND ol_w_id = %d]])
+                                      :format(table_num, no_o_id, d_id, w_id))
 
 --	UPDATE customer SET c_balance = c_balance + :ol_total ,
 --		                             c_delivery_cnt = c_delivery_cnt + 1
 --		                WHERE c_id = :c_id AND c_d_id = :d_id AND
 --				c_w_id = :w_id;*/
 --        print(string.format("update customer table %d, cid %d, did %d, wid %d balance %f",table_num, o_c_id, d_id, w_id, sm_ol_amount))  				
-        con:query(([[UPDATE customer%d SET c_balance = c_balance + %f,
-                c_delivery_cnt = c_delivery_cnt + 1
-                WHERE c_id = %d AND c_d_id = %d AND  c_w_id = %d]])
+        con:query(([[UPDATE customer%d 
+                        SET c_balance = c_balance + %f,
+                            c_delivery_cnt = c_delivery_cnt + 1
+                      WHERE c_id = %d 
+                        AND c_d_id = %d 
+                        AND c_w_id = %d]])
                       :format(table_num, sm_ol_amount, o_c_id, d_id, w_id))
-
-        ::continue::
+        end
+        
     end
     con:query("COMMIT")
 
@@ -696,15 +650,39 @@ function stocklevel()
 --	                WHERE d_id = :d_id
 --			AND d_w_id = :w_id;*/
 
-    rs = con:query(([[SELECT d_next_o_id FROM district%d
-             	      WHERE d_id = %d AND d_w_id= %d]])
-		:format( table_num, d_id, w_id))
+--  What variant of queries to use for stock_level transaction
+--  case1 - specification
+--  case2 - modified/simplified
 
+    local stock_level_queries="case2" 
     local d_next_o_id
-    for i = 1, rs.nrows do
-        row = rs:fetch_row()
-        d_next_o_id = row[1]
-    end
+    
+
+    d_next_o_id = con:query_row(([[SELECT d_next_o_id 
+                                     FROM district%d
+             	                    WHERE d_id = %d AND d_w_id= %d]])
+		                  :format( table_num, d_id, w_id))
+
+    if stock_level_queries == "case1" then 
+
+--[[
+     SELECT COUNT(DISTINCT (s_i_id)) INTO :stock_count
+     FROM order_line, stock
+     WHERE ol_w_id=:w_id AND ol_d_id=:d_id AND ol_o_id<:o_id AND  ol_o_id>=:o_id-20 AND s_w_id=:w_id AND s_i_id=ol_i_id AND s_quantity < :threshold;
+--]]
+
+    rs = con:query(([[SELECT COUNT(DISTINCT (s_i_id))
+                        FROM order_line%d, stock%d
+                       WHERE ol_w_id = %d 
+                         AND ol_d_id = %d
+                         AND ol_o_id < %d 
+                         AND ol_o_id >= %d
+                         AND s_w_id= %d
+                         AND s_i_id=ol_i_id 
+                         AND s_quantity < %d ]])
+		:format(table_num, table_num, w_id, d_id, d_next_o_id, d_next_o_id - 20, w_id, level ))
+
+
 
 --	                SELECT DISTINCT ol_i_id
 --	                FROM order_line
@@ -713,33 +691,36 @@ function stocklevel()
 --			AND ol_o_id < :d_next_o_id
 --			AND ol_o_id >= (:d_next_o_id - 20);
 
+
+    else
+
     rs = con:query(([[SELECT DISTINCT ol_i_id FROM order_line%d
                WHERE ol_w_id = %d AND ol_d_id = %d
                  AND ol_o_id < %d AND ol_o_id >= %d]])
-		:format(table_num, w_id, d_id, d_next_o_id, d_next_o_id - 20 ))
+                :format(table_num, w_id, d_id, d_next_o_id, d_next_o_id - 20 ))
 
     local ol_i_id
+
     for i = 1, rs.nrows do
-        row = rs:fetch_row()
-        ol_i_id = row[1]
+        ol_i_id = unpack(rs:fetch_row(), 1, rs.nfields)
 
 
---	 SELECT count(*) INTO :i_count
---			FROM stock
---			WHERE s_w_id = :w_id
---		        AND s_i_id = :ol_i_id
---			AND s_quantity < :level;*/
+--       SELECT count(*) INTO :i_count
+--                      FROM stock
+--                      WHERE s_w_id = :w_id
+--                      AND s_i_id = :ol_i_id
+--                      AND s_quantity < :level;*/
 
         rs1 = con:query(([[SELECT count(*) FROM stock%d
                    WHERE s_w_id = %d AND s_i_id = %d
                    AND s_quantity < %d]])
-		:format(table_num, w_id, ol_i_id, level ) )
+                :format(table_num, w_id, ol_i_id, level ) )
         local cnt
         for i = 1, rs1.nrows do
-            row1 = rs1:fetch_row()
-            cnt = row1[1]
+            cnt = unpack(rs1:fetch_row(), 1, rs1.nfields)
         end
 
+    end
     end
 
     con:query("COMMIT")


### PR DESCRIPTION
    tpcc scenario changes:
    - fixed delivery transaction to handle NULL case properly
    - modified stock_level transaction to support two type of queries

    compatibility changes:
    - modified prepare stage to keep tinyint for MySQL and smallint for other DBs
    - fixed check stage to support STRAIGHT_JOIN hint for MySQL

    core script changes:
    - replaced os.sleep with ffi.C.usleep
    - replaced pcall() with proper hook for error handling
    - changed API calls from :query to :query_row
    - various small cleanups and imporvements