### PR TITLE
Bypassed `SET autocommit` like query in `tpcc_common.lua` when using pgsql

### DIFF
--- a/tpcc_common.lua
+++ b/tpcc_common.lua
@@ -407,7 +407,9 @@ function load_tables(drv, con, warehouse_num)
    local extra_table_options = ""
    local query
 
-   con:query("SET autocommit=1")
+   if drv:name() == "mysql" then
+      con:query("SET autocommit=1")
+   end
 
    -- print(string.format("Creating warehouse: %d\n", warehouse_num))
 


### PR DESCRIPTION
Since the `autocommit` parameter is no longer supported in newer version of pgsql.