### PR TITLE
Fix force_pk in PostgreSQL

### DIFF
--- a/tpcc_common.lua
+++ b/tpcc_common.lua
@@ -222,7 +222,11 @@ function create_tables(drv, con, table_num)
    local hist_auto_inc=""
    local hist_pk=""
    if sysbench.opt.force_pk == 1 then
-      hist_auto_inc="id int NOT NULL AUTO_INCREMENT,"
+      if drv:name() == "pgsql" then
+         hist_auto_inc="id serial NOT NULL,"
+      else
+         hist_auto_inc="id int NOT NULL AUTO_INCREMENT,"
+      end
       hist_pk=",PRIMARY KEY(id)"
    end
    query = string.format([[


### PR DESCRIPTION
The current implementation of the auto incremented primary key in the History table uses `id int NOT NULL AUTO_INCREMENT` for all database engines. However, the correct code for PostgreSQL should be `id serial NOT NULL`, as can be confirmed in the [docs](https://www.postgresql.org/docs/current/datatype-numeric.html#DATATYPE-SERIAL).

Currently, the `prepare` results in the following error:
```
FATAL: PQexec() failed: 7 syntax error at or near "AUTO_INCREMENT"
FATAL: failed query was:        create table IF NOT EXISTS history1 (
        id int NOT NULL AUTO_INCREMENT,
        h_c_id int,
        h_c_d_id smallint,
        h_c_w_id smallint,
        h_d_id smallint,
        h_w_id smallint,
        h_date timestamp,
        h_amount decimal(6,2),
        h_data varchar(24) ,PRIMARY KEY(id)
        )
FATAL: `sysbench.cmdline.call_command' function failed: ./tpcc_common.lua:242: SQL error, errno = 0, state = '42601': syntax error at or near "AUTO_INCREMENT"
```

This commit fixes this error.