### PR TITLE
Implement option --splittable=yes|no

### DIFF
--- a/tpcc_common.lua
+++ b/tpcc_common.lua
@@ -62,7 +62,9 @@ sysbench.cmdline.options = {
    mysql_storage_engine =
       {"Storage engine, if MySQL is used", "innodb"},
    mysql_table_options =
-      {"Extra table options, if MySQL is used. e.g. 'COLLATE latin1_bin'", ""}
+      {"Extra table options, if MySQL is used. e.g. 'COLLATE latin1_bin'", ""},
+   splittable =
+      {"Create READ WRITE or READ ONLY transactions to allow using a splitting proxy", "no"}
 }
 
 function sleep(n)

--- a/tpcc_run.lua
+++ b/tpcc_run.lua
@@ -77,7 +77,12 @@ function new_order()
 --  AND c_d_id = :d_id 
 --  AND c_id = :c_id;
 
-  con:query("BEGIN")
+  if (sysbench.opt.splittable == "yes")
+  then
+      con:query("START TRANSACTION READ WRITE")
+  else
+      con:query("BEGIN")
+  end
 
   local c_discount
   local c_last
@@ -253,7 +258,12 @@ function payment()
 --  UPDATE warehouse SET w_ytd = w_ytd + :h_amount
 --  WHERE w_id =:w_id
 
-  con:query("BEGIN")
+  if (sysbench.opt.splittable == "yes")
+  then
+      con:query("START TRANSACTION READ WRITE")
+  else
+      con:query("BEGIN")
+  end
 
   con:query(([[UPDATE warehouse%d
 	          SET w_ytd = w_ytd + %d 
@@ -427,7 +437,13 @@ function orderstatus()
     local c_balance
     local c_first
     local c_middle
-    con:query("BEGIN")
+
+    if (sysbench.opt.splittable == "yes")
+    then
+        con:query("START TRANSACTION READ ONLY")
+    else
+        con:query("BEGIN")
+    end
 
     if byname == 1 then
 --    /*EXEC_SQL SELECT count(c_id)
@@ -552,7 +568,13 @@ function delivery()
     local w_id = sysbench.rand.uniform(1, sysbench.opt.scale)
     local o_carrier_id = sysbench.rand.uniform(1, 10)
 
-    con:query("BEGIN")
+    if (sysbench.opt.splittable == "yes")
+    then
+        con:query("START TRANSACTION READ WRITE")
+    else
+        con:query("BEGIN")
+    end
+
     for  d_id = 1, DIST_PER_WARE do
 
 --	SELECT COALESCE(MIN(no_o_id),0) INTO :no_o_id
@@ -659,7 +681,12 @@ function stocklevel()
     local d_id = sysbench.rand.uniform(1, DIST_PER_WARE)
     local level = sysbench.rand.uniform(10, 20)
 
-    con:query("BEGIN")
+    if (sysbench.opt.splittable == "yes")
+    then
+        con:query("START TRANSACTION READ ONLY")
+    else
+        con:query("BEGIN")
+    end
 
 --	/*EXEC_SQL SELECT d_next_o_id
 --	                FROM district
@@ -752,7 +779,12 @@ function purge()
     local w_id = sysbench.rand.uniform(1, sysbench.opt.scale)
     local d_id = sysbench.rand.uniform(1, DIST_PER_WARE)
 
-    con:query("BEGIN")
+    if (sysbench.opt.splittable == "yes")
+    then
+        con:query("START TRANSACTION READ WRITE")
+    else
+        con:query("BEGIN")
+    end
 
         local m_o_id
         


### PR DESCRIPTION
If this option is enabled sysbench-tpcc will start transactions with
START TRANSACTION READ ONLY resp. START TRANSACTION READ WRITE
instead of using a BEGIN statement.

This allows to use a filtering proxy (i.e. MaxScale) to separate
read-only transactions and route them to a replica.